### PR TITLE
jqFundamentals -> learn.jquery.com

### DIFF
--- a/data/jquery.json
+++ b/data/jquery.json
@@ -18,9 +18,9 @@
       "description": "",
       "links": [
         {
-          "description": "jQuery Fundamentals",
+          "description": "Official learning center",
           "type": "website",
-          "url": "http://jqfundamentals.com"
+          "url": "http://learn.jquery.com"
         },
         {
           "description": "30 Days to learn jQuery (free with account)",


### PR DESCRIPTION
jqfundamentals moved to learn.jquery.com. The original site is outdated these days, and not maintained anymore. http://learn.jquery.com/about/#history