### PR TITLE
Convert indentation to tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,10 +38,9 @@
 							</li>
 						{{/each}}
 					</ul>
-
 				</li>
-	    	{{/each}}
-    	</ul>
+			{{/each}}
+		</ul>
 
 	</script>
 


### PR DESCRIPTION
Seems like you have space and tabs indentation at same time, so it allow to incorrect indentation on GitHub. Fixed it.
